### PR TITLE
fix loki config

### DIFF
--- a/config/loki-config.yml
+++ b/config/loki-config.yml
@@ -65,5 +65,9 @@ query_range:
 querier:
   max_concurrent: 2048
 
+chunk_store_config:
+  chunk_cache_config:
+    enable_fifocache: false
+
 analytics:
   reporting_enabled: false

--- a/config/loki-config.yml
+++ b/config/loki-config.yml
@@ -29,7 +29,6 @@ schema_config:
 storage_config:
   boltdb:
     directory: /tmp/loki/index
-
   filesystem:
     directory: /tmp/loki/chunks
 
@@ -57,6 +56,11 @@ frontend:
 
 query_range:
   parallelise_shardable_queries: false
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
 
 querier:
   max_concurrent: 2048

--- a/config/loki-config.yml
+++ b/config/loki-config.yml
@@ -60,3 +60,6 @@ query_range:
 
 querier:
   max_concurrent: 2048
+
+analytics:
+  reporting_enabled: false


### PR DESCRIPTION
Addresses the following log messages:

```level=warn ts=2022-10-20T12:56:56.292959463Z caller=cache.go:115 msg="fifocache config is deprecated. use embedded-cache instead"```

```level=info ts=2022-09-12T14:20:05.981947252Z caller=reporter.go:282 msg="failed to report usage" err="5 errors: Post \[https://stats.grafana.org/loki-usage-report\](https://stats.grafana.org/loki-usage-report/): dial tcp 34.96.126.106:443: connect: connection refused; Post \[https://stats.grafana.org/loki-usage-report\](https://stats.grafana.org/loki-usage-report/): dial tcp 34.96.126.106:443: connect: connection refused; Post \[https://stats.grafana.org/loki-usage-report\](https://stats.grafana.org/loki-usage-report/): dial tcp 34.96.126.106:443: connect: connection refused; Post \[https://stats.grafana.org/loki-usage-report\](https://stats.grafana.org/loki-usage-report/): dial tcp 34.96.126.106:443: connect: connection refused; Post \[https://stats.grafana.org/loki-usage-report\](https://stats.grafana.org/loki-usage-report/): dial tcp 34.96.126.106:443: connect: connection refused"```